### PR TITLE
Fix an error in config.jelly which prevents configuring jobs in IE7

### DIFF
--- a/src/main/resources/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder/config.jelly
@@ -23,7 +23,6 @@ THE SOFTWARE.
 -->
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <P>behavior: ${instance.behavior}</P>
   <f:entry title="Groovy script:">
     <f:textarea field="groovyScript" />
   </f:entry>


### PR DESCRIPTION
This line seems to be left from an "debuggin-by-printing-session" :-) and causes an error at least in Internet Explorer 7.
