### PR TITLE
Fixed classloader issues related with import statement could NOT find other plugins packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <name>Groovy Postbuild</name>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>groovy-postbuild</artifactId>
-    <version>1.9-SNAPSHOT</version>
+    <version>1.9-SNAPSHOT-halyph</version>
     <packaging>hpi</packaging>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Groovy+Postbuild+Plugin</url>
 

--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
@@ -269,7 +269,14 @@ public class GroovyPostbuildRecorder extends Recorder {
 			case 2: scriptFailureResult = Result.FAILURE; break;
 		}
 		BadgeManager badgeManager = new BadgeManager(build, listener, scriptFailureResult, getDescriptor().isSecurityEnabled());
-        ClassLoader cl = new URLClassLoader(getClassPath(), getClass().getClassLoader());
+        //ClassLoader cl = new URLClassLoader(getClassPath(), getClass().getClassLoader());
+		// Intentionally commented the previous CL instantiation because Groovy script doesn't
+		// have access to plugins. I.e. import statement could NOT find anything
+		ClassLoader cl = Hudson.getInstance().getPluginManager().uberClassLoader;
+        if (cl == null) {
+            cl = Thread.currentThread().getContextClassLoader();
+        }
+
 		GroovyShell shell = new GroovyShell(cl);
         shell.setVariable("manager", badgeManager);
         try {


### PR DESCRIPTION
We have a use case when we need to consume functionality of other Jenkins plugins, but the current implementation couldn't find packages (on class path) from other plugins. This small changes fixed this issue.
