### PR TITLE
Enabled ABORTED and NOT_BUILT states

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
@@ -168,6 +168,12 @@ public class GroovyPostbuildRecorder extends Recorder {
 		public void buildSuccess() {
 			build.setResult(Result.SUCCESS);
 		}
+    public void buildAborted() {
+      build.setResult(Result.ABORTED);
+    }
+    public void buildNotBuilt() {
+      build.setResult(Result.NOT_BUILT);
+    }
 
 		public void buildScriptFailed(Exception e) {
 			StringWriter writer = new StringWriter();

--- a/src/main/resources/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder/help.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder/help.jelly
@@ -31,6 +31,8 @@
     <li><code>buildUnstable()</code> - sets the build result to <i>UNSTABLE</i>.</li>
     <li><code>buildFailure()</code> - sets the build result to <i>FAILURE</i>.</li>
     <li><code>buildSuccess()</code> - sets the build result to <i>SUCCESS</i>.</li>
+    <li><code>buildAborted()</code> - sets the build result to <i>ABORTED</i>.</li>
+    <li><code>buildNotBuilt()</code> - sets the build result to <i>NOT_BUILT</i>.</li>
   </ul>
   Example:<pre><code>    if(manager.logContains(".*uses or overrides a deprecated API.*")) {
       manager.addWarningBadge("Thou shalt not use deprecated methods.")


### PR DESCRIPTION
Hello,

it would be helpful for us to enable setting ABORTED and NOT_BUILT build results (additionally to SUCCESS, FAILURE and UNSTABLE).

Background:
Having a Maven CI job (building snapshot versions and deploying to a snapshot repo) and a release job (building non-snapshot versions and releasing to a milestone or release repo) the CI job always fails during a release because non-snapshot versions cannot be deployed to a snapshot repo.
Since we cannot prevent the CI job from being triggered the better semantic than FAILURE would be NOT_BUILD or ABORTED if we identify a non-snapshot version in a snapshot CI build.

Thanks and regards,
Alex
