### PR TITLE
change log level for each search from info to fine

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
@@ -207,7 +207,7 @@ public class GroovyPostbuildRecorder extends Recorder {
 	    }
 
 	    public Matcher getMatcher(File f, String regexp) {
-	    	LOGGER.info("Searching for '" + regexp + "' in '" + f + "'.");
+	    	LOGGER.fine("Searching for '" + regexp + "' in '" + f + "'.");
 			Matcher matcher = null;
 			BufferedReader reader = null;
 			try {


### PR DESCRIPTION
When running the matching functionality on a large number of jobs the Jenkins log becomes flooded by all these messages. By changing the log level from `info` to `fine` the verbosity is avoided and when someone is interested in the detailed information they are still accessible by configuring a custom log level.
