### PR TITLE
Added EnvVars hashmap if you have the EnvInject plugin

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildDescriptor.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildDescriptor.java
@@ -23,6 +23,7 @@
  */
 package org.jvnet.hudson.plugins.groovypostbuild;
 
+import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 
 import org.kohsuke.stapler.StaplerRequest;
@@ -37,6 +38,7 @@ import hudson.tasks.Publisher;
 public class GroovyPostbuildDescriptor extends BuildStepDescriptor<Publisher> {
 
 	private boolean enableSecurity = false;
+
 
     /**
      * Constructs a {@link GroovyPostbuildDescriptor}.
@@ -54,6 +56,10 @@ public class GroovyPostbuildDescriptor extends BuildStepDescriptor<Publisher> {
         return "Groovy Postbuild";
     }
 
+    public boolean hasEnvInject(){
+    	return (Jenkins.getInstance().getPlugin("envinject") != null);
+    }
+    
     @Override
     public String getHelpFile() {
         return super.getHelpFile();

--- a/src/main/resources/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder/config.jelly
@@ -42,7 +42,7 @@ THE SOFTWARE.
   </f:entry>
 
   <f:entry title="If the script fails:" field="behavior">
-    <select name="groovypostbuild.groovyPostbuilRecorder.behavior" align="right" >
+    <select name="groovypostbuild.groovyPostbuildRecorder.behavior" align="right" >
       <f:option value="0" selected="${instance.behavior == 0}">Do nothing</f:option>
       <f:option value="1" selected="${instance.behavior == 1}">Mark build as unstable</f:option>
       <f:option value="2" selected="${instance.behavior == 2}">Mark build as failed</f:option>
@@ -55,4 +55,6 @@ THE SOFTWARE.
       <f:checkbox />
     </f:entry>
   </j:if>
+  
+  
 </j:jelly>

--- a/src/main/resources/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder/help.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder/help.jelly
@@ -39,6 +39,8 @@
       manager.createSummary("warning.gif").appendText("&amp;lt;h1&amp;gt;You have been warned!&amp;lt;/h1&amp;gt;", false, false, false, "red")
       manager.buildUnstable()
     }</code></pre>
+	The script can also use the variable "envVars", which is a HashMap of all of the environment variables including any set using EnvInject. This is different from using $WORKSPACE, which is not ideal in master/slave scenarios.
+	Example:<pre><code>	def app_data = envVars["APPDATA"] </code></pre>
   See <a href="https://wiki.jenkins-ci.org/display/JENKINS/Groovy+Postbuild+Plugin">Jenkins Wiki</a> for more information.
 </div>
 </l:ajax>


### PR DESCRIPTION
I noticed that getting the build's environment variables is tricky and is really catered towards parameterized builds. I added an optional dependency, the EnvInject plugin, that allows the user to grab any injected or environmental variable in the build. The user can access these from a HashMap "envVars" in the script much like how they access the badgeManager with the "manager" variable.
