### PR TITLE
Added compatibleSinceVersion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,19 @@
       </developer>
     </developers>
     
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jvnet.hudson.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <compatibleSinceVersion>2.0</compatibleSinceVersion>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/groovy-postbuild-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/groovy-postbuild-plugin.git</developerConnection>


### PR DESCRIPTION
To display warnings like: https://wiki.jenkins-ci.org/display/JENKINS/Marking+a+new+plugin+version+as+incompatible+with+older+versions#Markinganewpluginversionasincompatiblewitholderversions-ModificationtoDisplayofUpdateablePluginList

Though the Wiki page says that I need use "compatibleSinceVersion" when automatic data format upgrade can't be applied, the warning text looks proper for this case.
