### PR TITLE
[JENKINS-25738] added getResult() as a whitelisted method

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
@@ -154,6 +154,10 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
 		public void addErrorBadge(String text) {
 			build.getActions().add(GroovyPostbuildAction.createErrorBadge(text));
 		}
+
+		@Whitelisted
+		public String getResult() { return build.getResult().toString(); }
+
 		@Whitelisted
 		public void removeBadges() {
 			List<Action> actions = build.getActions();

--- a/src/main/resources/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder/help.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder/help.jelly
@@ -12,6 +12,7 @@
     <li><code>logContains(regexp)</code> - returns true if the build log file contains a line matching <i>regexp</i>.</li>
     <li><code>getMatcher(file, regexp)</code> - returns a java.util.regex.Matcher for the first occurrence of <i>regexp</i> in the given file.</li>
     <li><code>getLogMatcher(regexp)</code> - returns a java.util.regex.Matcher for the first occurrence of <i>regexp</i> in the build log file.</li>
+    <li><code>getResult()</code> - returns the current build result.</li>
     <P/>
     <li><code>addShortText(text)</code> - puts a badge with a short text, using the default format.</li>
     <li><code>addShortText(text, color, background, border, borderColor)</code> - puts a badge with a short text, using the specified format.</li>


### PR DESCRIPTION
I created a fix for JENKINS-25738. The `getResult()` method will return the build's result as a string.
