### PR TITLE
Fix GroovyPostBuild plugin incorrectly reporting that it failed

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
@@ -345,6 +345,7 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
 	@Override
 	public final boolean perform(final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener) throws InterruptedException, IOException {
         Hudson.getInstance().checkPermission(Hudson.ADMINISTER);
+		boolean scriptResult = true;
 		LOGGER.fine("perform() called for script");
 		LOGGER.fine("behavior: " + behavior);
 		Result scriptFailureResult = Result.SUCCESS;
@@ -363,11 +364,12 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
             // TODO could print more refined errors for UnapprovedUsageException and/or RejectedAccessException:
 			e.printStackTrace(listener.error("Failed to evaluate groovy script."));
 			badgeManager.buildScriptFailed(e);
+			scriptResult = false;
 		}
 		for(AbstractBuild<?, ?> b : badgeManager.builds) {
 			b.save();
 		}
-		return build.getResult().isBetterThan(Result.FAILURE);
+		return scriptResult;
 	}
 
     public final BuildStepMonitor getRequiredMonitorService() {

--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
@@ -369,7 +369,12 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
 		for(AbstractBuild<?, ?> b : badgeManager.builds) {
 			b.save();
 		}
-		return scriptResult;
+		
+		if (!scriptResult && scriptFailureResult.isWorseOrEqualTo(Result.FAILURE)){
+			return false;
+		} else {
+			return true;
+		}
 	}
 
     public final BuildStepMonitor getRequiredMonitorService() {


### PR DESCRIPTION
Currently The Groovy Postbuild Plugin always reports that it it failed if the current build result is a failure or worse.  However, in the case where the build has already been marked as a failure for unrelated reasons (such as, for example, an ant script failing), this can cause Jenkins to behave in unwanted ways, such as causing post build actions after Groovy PostBuild to not execute.

The changes in this branch change the behavior so that the plugin only claims it failed if the script itself fails to execute and the plugin is set to fail the build if script execution failed.  This should more accurately reflect what has actually happened, and cause Jenkins to behave in a more expected manner.  If this behavior isn't acceptable, I'm willing to compromise.

Example logs with invalid "Invoke Ant" step and the following Groovy Postbuild script:

```
manager.listener.logger.println("WHEEEEE")
```

Before:

```
Started by user anonymous
Building in workspace /home/jenkins/.jenkins/jobs/test job/workspace
FATAL: Unable to find build script at /home/jenkins/.jenkins/jobs/test job/workspace/build.xml
Build step 'Invoke Ant' marked build as failure
WHEEEEE
Build step 'Groovy Postbuild' marked build as failure
Finished: FAILURE
```

After

```
Started by user anonymous
Building in workspace /home/jenkins/.jenkins/jobs/test job/workspace
FATAL: Unable to find build script at /home/jenkins/.jenkins/jobs/test job/workspace/build.xml
Build step 'Invoke Ant' marked build as failure
WHEEEEE
Finished: FAILURE
```