### PR TITLE
[JENKINS-32589] Dependency to workflow-plugin should be optional.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
             <version>${workflow.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/WorkflowManager.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/WorkflowManager.java
@@ -37,7 +37,7 @@ import org.jenkinsci.plugins.workflow.cps.GlobalVariable;
 /**
  * Exposes {@link org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder.BadgeManager} to Workflow scripts as {@code manager}.
  */
-@Extension
+@Extension(optional=true)
 public class WorkflowManager extends GlobalVariable {
 
     @Override


### PR DESCRIPTION
[JENKINS-32589](https://issues.jenkins-ci.org/browse/JENKINS-32589).

Groovy-postbuild 2.3 starts to depend on workflow-cps, which results forcing to install following additional plugins when you install / upgrade groovy-postbuild.
* Pipeline: Step API
* MapDB API Plugin
* SCM API Plugin
* Subversion Plug-in
* Pipeline: SCM Step
* Pipeline: API
* Durable Task Plugin
* Pipeline: Execution Support
* JavaScript GUI Lib: jQuery bundles (jQuery and jQuery UI) plugin
* JavaScript GUI Lib: ACE Editor bundle plugin
* Pipeline: Groovy CPS Execution 

Users installing groovy-postbuild don't always need workflow plugin (now called pipeline plugin), and those dependency should be optional.

Only `WorkflowManager` is affected by this change. See #24 for details of the dependency to workflow.