### PR TITLE
Run a Groovy script from the file system.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,5 @@
+stage('BUILD') {
+    node('master') {
+        checkout scm
+    }
+}

--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
@@ -324,8 +324,12 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
 	}
 
 	@DataBoundConstructor
-	public GroovyPostbuildRecorder(boolean groovyFromFile, String filePath, SecureGroovyScript script, int behavior, boolean runForMatrixParent) 
-			throws IOException {
+	public GroovyPostbuildRecorder(
+			boolean groovyFromFile, 
+			String filePath, 
+			SecureGroovyScript script, 
+			int behavior, 
+			boolean runForMatrixParent) {
 		
 		this.groovyFromFile = groovyFromFile;
 		this.filePath = filePath;

--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
@@ -63,8 +63,7 @@ import org.jenkinsci.plugins.scriptsecurity.scripts.ClasspathEntry;
 public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregatable {
 	private static final Logger LOGGER = Logger.getLogger(GroovyPostbuildRecorder.class.getName());
 
-	private boolean groovyFromFile;
-	private String filePath;
+	private String groovyFilePath;
 	@Deprecated private String groovyScript;
     private SecureGroovyScript script;
 	private final int behavior;
@@ -323,20 +322,19 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
 		}
 	}
 
+    
 	@DataBoundConstructor
 	public GroovyPostbuildRecorder(
-			boolean groovyFromFile, 
-			String filePath, 
+			String groovyFilePath, 
 			SecureGroovyScript script, 
 			int behavior, 
 			boolean runForMatrixParent) {
-		
-		this.groovyFromFile = groovyFromFile;
-		this.filePath = filePath;
-		if (this.groovyFromFile == true && this.filePath != null && !this.filePath.trim().equals("")) {
+				
+		this.groovyFilePath = groovyFilePath;
+		if (this.groovyFilePath != null && !this.groovyFilePath.trim().equals("")) {
 			try {
 				// Read file
-				FilePath fp = new FilePath(new File(this.filePath));
+				FilePath fp = new FilePath(new File(this.groovyFilePath));
 				String contentOfGroovyFile = new Scanner(fp.read()).useDelimiter("\\A").next();
 				
 				// take the same values from UI, except the content
@@ -346,13 +344,14 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
 						script.isSandbox(),
 						script.getClasspath());
 				this.script = scriptFromFile;
+				this.script = script.configuringWithNonKeyItem();
 			} catch(IOException ioexc) {
 				// Write error message into logger
-				LOGGER.log(Level.WARNING, "[GroovyPostbuild] Error loading file " + this.filePath, ioexc);
+				LOGGER.log(Level.WARNING, "[GroovyPostbuild] Error loading file " + this.groovyFilePath, ioexc);
 				// and then use default behaviour
 				this.script = script.configuringWithNonKeyItem();
 			} catch (InterruptedException intexc) {
-				LOGGER.log(Level.WARNING, "[GroovyPostbuild] InterruptedException occurred with file " + this.filePath, intexc);
+				LOGGER.log(Level.WARNING, "[GroovyPostbuild] InterruptedException occurred with file " + this.groovyFilePath, intexc);
 				// no default behaviour
 			}
 		} else {
@@ -426,10 +425,6 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
 			return true;
 		}
 	}
-
-	public boolean getGroovyFromFile() {
-		return this.groovyFromFile;
-	}
 	
     public final BuildStepMonitor getRequiredMonitorService() {
 		return BuildStepMonitor.NONE;
@@ -439,8 +434,8 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
 		return script;
 	}
 	
-	public String getFilePath() {
-		return filePath;
+	public String getGroovyFilePath() {
+		return groovyFilePath;
 	}
 
 	public int getBehavior() {

--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
@@ -63,6 +63,7 @@ import org.jenkinsci.plugins.scriptsecurity.scripts.ClasspathEntry;
 public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregatable {
 	private static final Logger LOGGER = Logger.getLogger(GroovyPostbuildRecorder.class.getName());
 
+	private boolean groovyFromFile;
 	private String filePath;
 	@Deprecated private String groovyScript;
     private SecureGroovyScript script;
@@ -323,10 +324,12 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
 	}
 
 	@DataBoundConstructor
-	public GroovyPostbuildRecorder(String filePath, SecureGroovyScript script, int behavior, boolean runForMatrixParent) 
+	public GroovyPostbuildRecorder(boolean groovyFromFile, String filePath, SecureGroovyScript script, int behavior, boolean runForMatrixParent) 
 			throws IOException {
+		
+		this.groovyFromFile = groovyFromFile;
 		this.filePath = filePath;
-		if (this.filePath != null && !this.filePath.trim().equals("")) {
+		if (this.groovyFromFile == true && this.filePath != null && !this.filePath.trim().equals("")) {
 			try {
 				// Read file
 				FilePath fp = new FilePath(new File(this.filePath));
@@ -420,6 +423,10 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
 		}
 	}
 
+	public boolean getGroovyFromFile() {
+		return this.groovyFromFile;
+	}
+	
     public final BuildStepMonitor getRequiredMonitorService() {
 		return BuildStepMonitor.NONE;
 	}

--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
@@ -336,15 +336,14 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
 				// Read file
 				FilePath fp = new FilePath(new File(this.groovyFilePath));
 				String contentOfGroovyFile = new Scanner(fp.read()).useDelimiter("\\A").next();
-				
+					
 				// take the same values from UI, except the content
 				// of the script.
-				SecureGroovyScript scriptFromFile = new SecureGroovyScript(
+				this.script = new SecureGroovyScript(
 						contentOfGroovyFile, 
 						script.isSandbox(),
 						script.getClasspath());
-				this.script = scriptFromFile;
-				this.script = script.configuringWithNonKeyItem();
+				this.script = this.script.configuringWithNonKeyItem();
 			} catch(IOException ioexc) {
 				// Write error message into logger
 				LOGGER.log(Level.WARNING, "[GroovyPostbuild] Error loading file " + this.groovyFilePath, ioexc);

--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
@@ -61,6 +61,7 @@ import org.jenkinsci.plugins.scriptsecurity.scripts.ClasspathEntry;
 public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregatable {
 	private static final Logger LOGGER = Logger.getLogger(GroovyPostbuildRecorder.class.getName());
 
+	private String filePath;
 	@Deprecated private String groovyScript;
     private SecureGroovyScript script;
 	private final int behavior;
@@ -320,7 +321,8 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
 	}
 
 	@DataBoundConstructor
-	public GroovyPostbuildRecorder(SecureGroovyScript script, int behavior, boolean runForMatrixParent) {
+	public GroovyPostbuildRecorder(String filePath, SecureGroovyScript script, int behavior, boolean runForMatrixParent) {
+		this.filePath = filePath;
         this.script = script.configuringWithNonKeyItem();
 		this.behavior = behavior;
 		this.runForMatrixParent = runForMatrixParent;
@@ -359,6 +361,13 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
 	public final boolean perform(final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener) throws InterruptedException, IOException {
         Hudson.getInstance().checkPermission(Hudson.ADMINISTER);
 		boolean scriptResult = true;
+		
+		if (this.filePath != null && this.filePath != "") {
+			FilePath fp = new FilePath(this.filePath);
+			String contentOfGroovyFile = new Scanner(fp.read()).useDelimiter("\\A").next();
+			
+		}
+		
 		LOGGER.fine("perform() called for script");
 		LOGGER.fine("behavior: " + behavior);
 		Result scriptFailureResult = Result.SUCCESS;
@@ -397,6 +406,10 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
 
 	public SecureGroovyScript getScript() {
 		return script;
+	}
+	
+	public String getFilePath() {
+		return filePath;
 	}
 
 	public int getBehavior() {

--- a/src/main/resources/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder/config.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
   			<f:textbox name="filePath" value="" />
   		</f:entry>
   	</f:optionalBlock>
-  <f:block>
+  </f:block>
   
   
   <f:property field="script"/>

--- a/src/main/resources/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder/config.jelly
@@ -25,14 +25,9 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry/><!-- just for help.html -->
   
-  <f:block>
-  	<f:optionalBlock title="Groovy script from file" name="groovyFromFile">
-  		<f:entry title="File path">
-  			<f:textbox name="filePath" value="" />
-  		</f:entry>
-  	</f:optionalBlock>
-  </f:block>
-  
+  <f:entry title="File path" field="groovyFilePath">
+  	<f:textbox />
+  </f:entry>
   
   <f:property field="script"/>
 

--- a/src/main/resources/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder/config.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder/config.jelly
@@ -24,6 +24,16 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry/><!-- just for help.html -->
+  
+  <f:block>
+  	<f:optionalBlock title="Groovy script from file" name="groovyFromFile">
+  		<f:entry title="File path">
+  			<f:textbox name="filePath" value="" />
+  		</f:entry>
+  	</f:optionalBlock>
+  <f:block>
+  
+  
   <f:property field="script"/>
 
   <f:entry title="If the script fails:" field="behavior">

--- a/src/main/resources/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder/help-groovyFilePath.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder/help-groovyFilePath.jelly
@@ -1,0 +1,5 @@
+<div>
+<p>
+Instead of writing a script, you can enter a path to a Groovy script on the computer, where the job is running. If this script is found successfully, this Groovy script will be run.
+</p>
+</div>


### PR DESCRIPTION
I have a use case with this plugin in my company: There are several jobs, which are using the same Groovy script. With the current version of this plugin, I have to write / copy'n'paste the same script in every job, which is in my view not very efficient. And when I want to change something in one script, I have to do the same change in all jobs.

So I wrote an additional functionality, where someone can give a path to a Groovy script. I.e. instead of having the same script several times across some Jenkins jobs, with the new functionality someone can write one script, which can be used by several jobs. 
So in the future, when someone wants to make a change to that script, then this person only needs to make change only at one spot.

I hope this explanation is understandable.
