### PR TITLE
[JENKINS-48922] - Update plugin to make it runnable in PCT

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,2 @@
+// Build the plugin using https://github.com/jenkins-infra/pipeline-library
+buildPlugin()

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.9</version>
+    <version>3.2</version>
   </parent>
 
     <name>Groovy Postbuild</name>
@@ -33,8 +33,8 @@
     </licenses>
     
   <properties>
-    <jenkins.version>1.609.1</jenkins.version>
-    <java.level>6</java.level>
+    <jenkins.version>1.625.3</jenkins.version>
+    <java.level>7</java.level>
     <workflow.version>1.11</workflow.version>
   </properties>
 
@@ -68,7 +68,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
     <dependencies>


### PR DESCRIPTION
@MarkEWaite has reported that the plugin is not compatible with JEP-200 due to serialization of StringBuilder to the disk ([JENKINS-48922](https://issues.jenkins-ci.org/browse/JENKINS-48922)). Generally it is a bad idea to do so, but I see no security concerns about that. So the fix will be against the core.

In order to verify the fix in PCT, I had to update the plugin POM a bit:

- [x] - Use parent POM 3.x
- [x] - Use Jenkins core 1.625.3. More than 95% of users are on newer versions according to http://stats.jenkins.io/pluginversions/groovy-postbuild.html
- [x] - Add Jenkinsfile

@reviewbybees @markewaite @ikedam 