### PR TITLE
[JENKINS-50420] Add fake GroovyPostbuildAction

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildAction.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildAction.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2010, Sun Microsystems, Inc., Serban Iordache
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jvnet.hudson.plugins.groovypostbuild;
+
+import com.jenkinsci.plugins.badge.action.BadgeAction;
+
+import hudson.model.BuildBadgeAction;
+
+/**
+ * Left for backward binary compatibilities.
+ *
+ * This doesn't provide any actual features.
+ *
+ * @deprecated use {@link BadgeAction} instead.
+ */
+@Deprecated
+public class GroovyPostbuildAction implements BuildBadgeAction {
+    private GroovyPostbuildAction() {}
+
+    /* Action methods */
+    public String getUrlName() { return ""; }
+    public String getDisplayName() { return ""; }
+    public String getIconFileName() { return null; }
+
+    public boolean isTextOnly() { return false; }
+    public String getIconPath() { return null; }
+    public String getText() { return ""; }
+    public String getColor() { return "#000000"; }
+    public String getBackground() { return "#FFFF00"; }
+    public String getBorder() { return "1px"; }
+    public String getBorderColor() { return "#C0C000"; }
+    public String getLink() { return null; }
+}


### PR DESCRIPTION
quick fix for https://issues.jenkins-ci.org/browse/JENKINS-50420

build-monitor plugin referes `GroovyPostbuildAction`.
Groovy-postbuild-2.4 removed `GroovyPostbuildAction` and it results exception when displaying build-monitor view:
![screenshot-2018-4-29 buildmonitor](https://user-images.githubusercontent.com/3115961/39404176-8e67b6a0-4bc8-11e8-8327-60cbf602e4cc.png)

This change avoids the exception.
This is just a workaround and doesn't recover the feature of build-monitor to cooperate with groovy-postbuild.
It should be fixed as the upgrade of build-monitor as to cooperate rather with badge-plugin. 
(jan-molak/jenkins-build-monitor-plugin#364, jan-molak/jenkins-build-monitor-plugin#365)
