### PR TITLE
JENKINS-52043: UnsupportedOperationException when using removeBadge(s)

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
@@ -176,19 +176,19 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
 
 		@Whitelisted
 		public void removeBadges() {
-			List<? extends Action> actions = build.getAllActions();
 			List<BadgeAction> badgeActions = build.getActions(BadgeAction.class);
-			actions.removeAll(badgeActions);
+			for (BadgeAction a : badgeActions) {
+				build.removeAction(a);
+			}
 		}
 		@Whitelisted
 		public void removeBadge(int index) {
-			List<? extends Action> actions = build.getAllActions();
 			List<BadgeAction> badgeActions = build.getActions(BadgeAction.class);
 			if(index < 0 || index >= badgeActions.size()) {
 				listener.error("Invalid badge index: " + index + ". Allowed values: 0 .. " + (badgeActions.size()-1));
 			} else {
 				BadgeAction action = badgeActions.get(index);
-				actions.remove(action);
+				build.removeAction(action);
 			}
 		}
 


### PR DESCRIPTION
As mentioned in JENKINS-52043, the reason for the exception is that _manager.getAllActions()_ returns an immutable collection, causing any remove actions to throw an exception.

This change removes the use of getAllActions, and instead uses the build object to directly remove BadgeAction items, using _build.removeAction()_.