### PR TITLE
[JENKINS-54262] Groovy post build should be able to run with non-administrator

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
@@ -361,7 +361,6 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
 
 	@Override
 	public final boolean perform(final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener) throws InterruptedException, IOException {
-        Hudson.getInstance().checkPermission(Hudson.ADMINISTER);
 		boolean scriptResult = true;
 		LOGGER.fine("perform() called for script");
 		LOGGER.fine("behavior: " + behavior);


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-54262

Old-days groovy-postbuild required the administrator permission for the security reason as running groovy could do anything in Jenkins.
But the current groovy-postbuild no longer require administrator permission as the security check is performed with script-security.
So we can remove the administrator permission check.
