### PR TITLE
[JENKINS-57917] Add `AddHtmlBadge` feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <jenkins.version>2.121.1</jenkins.version>
     <java.level>8</java.level>
-    <badge-plugin.version>1.2</badge-plugin.version>
+    <badge-plugin.version>1.5</badge-plugin.version>
     <workflow-step-api-plugin.version>2.20</workflow-step-api-plugin.version>
     <workflow-cps-plugin.version>2.69</workflow-cps-plugin.version>
   </properties>

--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
@@ -56,8 +56,10 @@ import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ApprovalContext;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ClasspathEntry;
 
+import com.jenkinsci.plugins.badge.action.AbstractBadgeAction;
 import com.jenkinsci.plugins.badge.action.BadgeAction;
 import com.jenkinsci.plugins.badge.action.BadgeSummaryAction;
+import com.jenkinsci.plugins.badge.action.HtmlBadgeAction;
 
 /** This class associates {@link BadgeAction}s to a build. */
 @SuppressWarnings("unchecked")
@@ -170,6 +172,11 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
 		}
 
         @Whitelisted
+        public void addHtmlBadge(String html) {
+            build.addAction(HtmlBadgeAction.createHtmlBadge(html));
+        }
+
+        @Whitelisted
         public String getResult() {
             Result r = build.getResult();
             return (r != null) ? r.toString() : null;
@@ -177,18 +184,18 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
 
 		@Whitelisted
 		public void removeBadges() {
-			List<BadgeAction> badgeActions = build.getActions(BadgeAction.class);
-			for (BadgeAction a : badgeActions) {
+			List<AbstractBadgeAction> badgeActions = build.getActions(AbstractBadgeAction.class);
+			for (AbstractBadgeAction a : badgeActions) {
 				build.removeAction(a);
 			}
 		}
 		@Whitelisted
 		public void removeBadge(int index) {
-			List<BadgeAction> badgeActions = build.getActions(BadgeAction.class);
+			List<AbstractBadgeAction> badgeActions = build.getActions(AbstractBadgeAction.class);
 			if(index < 0 || index >= badgeActions.size()) {
 				listener.error("Invalid badge index: " + index + ". Allowed values: 0 .. " + (badgeActions.size()-1));
 			} else {
-				BadgeAction action = badgeActions.get(index);
+				AbstractBadgeAction action = badgeActions.get(index);
 				build.removeAction(action);
 			}
 		}


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-57917

Added `AddHtmlBadge` to groovy-postbuild as a wrapper for the same feature of badge-plugin.

Existing badge features in groovy-postbuild doesn't accept HTML texts since 2.4.
Actually, that was unexpected regression introduced by my fault, but I didn't revert that for security reasons.
This provides an alternate way to use HTML for users used HTML texts in groovy-postbuild before 2.4.
