### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,9 +36,6 @@
   <properties>
     <jenkins.version>2.121.1</jenkins.version>
     <java.level>8</java.level>
-    <badge-plugin.version>1.5</badge-plugin.version>
-    <workflow-step-api-plugin.version>2.20</workflow-step-api-plugin.version>
-    <workflow-cps-plugin.version>2.69</workflow-cps-plugin.version>
   </properties>
 
   <scm>
@@ -65,7 +62,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>badge</artifactId>
-            <version>${badge-plugin.version}</version>
+            <version>1.5</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -73,68 +70,46 @@
             <version>1.12</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>script-security</artifactId>
+            <version>1.42</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>${workflow-cps-plugin.version}</version>
+            <version>2.54</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-step-api</artifactId>
-            <version>${workflow-step-api-plugin.version}</version>
-            <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.32</version>
+            <version>2.26</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.15</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>junit</artifactId>
-            <version>1.20</version>
+            <version>2.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
     <dependencyManagement>
+        <!-- To resolve RequireUpperBoundDeps errors -->
         <dependencies>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
-                <artifactId>workflow-step-api</artifactId>
-                <version>${workflow-step-api-plugin.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-api</artifactId>
-                <version>2.33</version>
+                <version>2.30</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-support</artifactId>
-                <version>3.3</version>
+                <version>2.21</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>scm-api</artifactId>
                 <version>2.2.6</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>structs</artifactId>
-                <version>1.19</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>script-security</artifactId>
-                <version>1.60</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.26</version>
+            <version>2.32</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -98,18 +98,28 @@
         <dependencies>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
+                <artifactId>workflow-step-api</artifactId>
+                <version>2.19</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-api</artifactId>
-                <version>2.30</version>
+                <version>2.32</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins.workflow</groupId>
                 <artifactId>workflow-support</artifactId>
-                <version>2.21</version>
+                <version>3.2</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>scm-api</artifactId>
                 <version>2.2.6</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>structs</artifactId>
+                <version>1.17</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
* Declared directly required versions in `<dependencies>` section.
    * "directly required" means "referenced from codes".
        * E.g. Added script-security as groovy-script uses `SecureGroovyScript`.
    * Removed workflow-step-api and junit-plugin as groovy-script itself doesn't use it even in tests.
        * `RequireUpperBoundDeps` problems are resolved with `<dependencyManagement>`.
* Reordered dependencies. Mandatory dependencies, optional dependencies and test dependencies.
* Use the least versions for depending plugins as they are considered requirements.
    * workflow-job-2.26 is required to test JENKINS-54128, and I use workflow-job-2.32 (current latest) as in #40 as I found it doesn't affect non-test dependencies.
* Removed properties to specify dependency versions.
    * No longer necessary as they are used to synchronize versions for artifacts without classifier and with classifier=tests.
