### PR TITLE
Require Java 11, test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,10 @@
-// Build the plugin using https://github.com/jenkins-infra/pipeline-library
-buildPlugin()
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+  useContainerAgent: true,
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.43</version>
+    <version>4.74</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,7 @@
     </licenses>
 
   <properties>
-    <jenkins.version>2.121.1</jenkins.version>
-    <java.level>8</java.level>
+    <jenkins.version>2.361.4</jenkins.version>
   </properties>
 
   <scm>
@@ -58,6 +57,19 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+
+    <dependencyManagement>
+	<dependencies>
+	    <dependency>
+		<groupId>io.jenkins.tools.bom</groupId>
+		<artifactId>bom-2.361.x</artifactId>
+		<version>2102.v854b_fec19c92</version>
+		<scope>import</scope>
+		<type>pom</type>
+	    </dependency>
+	</dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -67,60 +79,25 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>1.12</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.42</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.54</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.32</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <dependencyManagement>
-        <!-- To resolve RequireUpperBoundDeps errors -->
-        <dependencies>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins.workflow</groupId>
-                <artifactId>workflow-step-api</artifactId>
-                <version>2.19</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins.workflow</groupId>
-                <artifactId>workflow-api</artifactId>
-                <version>2.32</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins.workflow</groupId>
-                <artifactId>workflow-support</artifactId>
-                <version>3.2</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>scm-api</artifactId>
-                <version>2.2.6</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>structs</artifactId>
-                <version>1.17</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>  

--- a/src/test/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorderTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorderTest.java
@@ -519,7 +519,7 @@ public class GroovyPostbuildRecorderTest {
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
 
         assertThat(
-            j.createWebClient().getPage(p).asText(),
+            j.createWebClient().getPage(p).getVisibleText(),
             Matchers.containsString("some-badge-text")
         );
     }
@@ -696,7 +696,7 @@ public class GroovyPostbuildRecorderTest {
         ));
         FreeStyleBuild b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
         assertEquals(
-                Arrays.asList("<font color=\"Black\">Test2</font>"),
+                Arrays.asList("Test2"),
                 Lists.transform(
                         b.getActions(BadgeSummaryAction.class),
                         new Function<BadgeSummaryAction, String>() {

--- a/src/test/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorderTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorderTest.java
@@ -561,9 +561,9 @@ public class GroovyPostbuildRecorderTest {
 
         j.assertBuildStatusSuccess(p.scheduleBuild2(0));
 
-        assertEquals(
-            "foobar",
-            j.createWebClient().getPage(p).getElementById("added-as-badge").getTextContent()
+        assertThat(
+            j.createWebClient().getPage(p).getVisibleText(),
+            Matchers.containsString("foobar")
         );
     }
 


### PR DESCRIPTION
## Require Java 11, test with Java 21

Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 in early October and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change intentionally tests only two Java configurations, Java 17 and Java 21 because we believe that the risk of a regression that only affects Java 11 is low. We generate Java 11 byte code with the Java 17 and the Java 21 builds, so we're already testing Java 11 byte code.

Replaces pull requests:

* #54
* #52
* #48
* #44

### Testing done

Confirmed that tests pass with Java 21 on Linux.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
