### PR TITLE
Require Jenkins 2.426.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/groovy-postbuild-plugin</gitHubRepo>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.426.3</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
 
@@ -52,8 +52,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.361.x</artifactId>
-        <version>2102.v854b_fec19c92</version>
+        <artifactId>bom-2.426.x</artifactId>
+        <version>3105.v672692894683</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Require Jenkins 2.426.3 or newer

[Plugin installation statistics](https://stats.jenkins.io/pluginversions/groovy-postbuild.html) show that 86% of the installations of the most recent release (228.x) are already running Jenkins 2.426.3 or newer.  That release was 6 months ago.  Users that are upgrading the plugin are also upgrading Jenkins core.

### Testing done

Automated tests pass on my Linux computer with Java 21.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
