### PR TITLE
Fix tests failing with badge-plugin 2.5 onwards

### DIFF
--- a/src/test/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorderTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorderTest.java
@@ -43,6 +43,7 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.Result;
 import hudson.model.User;
+import hudson.util.VersionNumber;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -478,7 +479,15 @@ public class GroovyPostbuildRecorderTest {
 
             BadgeSummaryAction badgeSummaryAction = b.getAction(BadgeSummaryAction.class);
             assertNotNull(badgeSummaryAction);
-            assertEquals("/plugin/badge/images/info.gif", badgeSummaryAction.getIcon());
+
+            VersionNumber badgePluginVersion =
+                    j.getPluginManager().getPlugin("badge").getVersionNumber();
+
+            if (badgePluginVersion.isNewerThanOrEqualTo(new VersionNumber("2.5"))) {
+                assertEquals("symbol-information-circle", badgeSummaryAction.getIcon());
+            } else {
+                assertEquals("/plugin/badge/images/info.gif", badgeSummaryAction.getIcon());
+            }
             assertEquals("<b>summaryText</b>", badgeSummaryAction.getText());
         }
 
@@ -487,15 +496,28 @@ public class GroovyPostbuildRecorderTest {
             FreeStyleBuild b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
             assertNotNull(b);
 
+            VersionNumber badgePluginVersion =
+                    j.getPluginManager().getPlugin("badge").getVersionNumber();
+
             BadgeAction badgeAction = b.getAction(BadgeAction.class);
             assertNotNull(badgeAction);
-            assertEquals("/plugin/badge/images/success.gif", badgeAction.getIcon());
+
+            if (badgePluginVersion.isNewerThanOrEqualTo(new VersionNumber("2.5"))) {
+                assertEquals("symbol-status-blue", badgeAction.getIcon());
+            } else {
+                assertEquals("/plugin/badge/images/success.gif", badgeAction.getIcon());
+            }
             assertEquals("shortText", badgeAction.getText());
             assertEquals("https://jenkins.io/", badgeAction.getLink());
 
             BadgeSummaryAction badgeSummaryAction = b.getAction(BadgeSummaryAction.class);
             assertNotNull(badgeSummaryAction);
-            assertEquals("/plugin/badge/images/info.gif", badgeSummaryAction.getIcon());
+
+            if (badgePluginVersion.isNewerThanOrEqualTo(new VersionNumber("2.5"))) {
+                assertEquals("symbol-information-circle", badgeSummaryAction.getIcon());
+            } else {
+                assertEquals("/plugin/badge/images/info.gif", badgeSummaryAction.getIcon());
+            }
             assertEquals("<b>summaryText</b>", badgeSummaryAction.getText());
         }
     }


### PR DESCRIPTION
The changes in https://github.com/jenkinsci/badge-plugin/pull/208 cause test errors when using the latest `badge-plugin` version (see https://github.com/jenkinsci/badge-plugin/pull/208#pullrequestreview-2430716509). Please note that these changes do only affect the tests and do not cause incompatibilites.

This PR adds a version check to fix the failing tests.

Required for https://github.com/jenkinsci/bom/pull/3955

### Testing done

Sucessfully ran `mvn verify` with both, badge-plugin 2.4 and 2.5

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
