### PR TITLE
doc: Update icon reference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The groovy postbuild plugin doesn't ensure that the methods of the returned obje
     returns a *summary* object corresponding to this entry.
 
     The icon can be one of [IonIcons](https://ionic.io/ionicons) referenced by
-    `symbol-<name> plugin-ionicons-api`, or Jenkins Core icon referenced by
+    `symbol-<name> plugin-ionicons-api`, or Jenkins core icon referenced by
     `icon-<name>` or `symbol-<name>`. See examples [here](https://www.jenkins.io/doc/pipeline/steps/badge/#addbadge-add-badge).
 
     You can append text to the *summary* object by

--- a/README.md
+++ b/README.md
@@ -120,9 +120,13 @@ The groovy postbuild plugin doesn't ensure that the methods of the returned obje
 #### Summary modification
 
 -   `createSummary(icon)` - creates an entry in the build summary page and
-    returns a *summary* object corresponding to this entry. The icon
-    must be one of the [48x48 icons](https://github.com/jenkinsci/jenkins/tree/master/war/src/main/webapp/images/48x48)
-    offered by Jenkins. You can append text to the *summary* object by
+    returns a *summary* object corresponding to this entry.
+
+    The icon can be one of [IonIcons](https://ionic.io/ionicons) referenced by
+    `symbol-<name> plugin-ionicons-api`, or Jenkins Core icon referenced by
+    `icon-<name>` or `symbol-<name>`. See examples [here](https://www.jenkins.io/doc/pipeline/steps/badge/#addbadge-add-badge).
+
+    You can append text to the *summary* object by
     calling its *appendText* methods. Be careful appending
     HTML-unescaped texts as they can be harmful.
     -   `appendText(text, escapeHtml)`


### PR DESCRIPTION
Looks like the old 48x48 icons are phasing out.

### Testing done

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
