### PR TITLE
Support badge-plugin 3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>6166.va_a_8b_5eda_8ef5</version>
+        <version>6210.v69ea_fd8a_f010</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -59,7 +59,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>badge</artifactId>
-      <version>3.583.vdc8d4a_a_1d586</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>6.2116.v7501b_67dc517</version>
+    <version>6.2138.v03274d462c13</version>
     <relativePath />
   </parent>
 
@@ -36,7 +36,7 @@
     <gitHubRepo>jenkinsci/groovy-postbuild-plugin</gitHubRepo>
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.baseline>2.541</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
@@ -48,7 +48,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>5054.v620b_5d2b_d5e6</version>
+        <version>6166.va_a_8b_5eda_8ef5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -59,6 +59,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>badge</artifactId>
+      <version>3.583.vdc8d4a_a_1d586</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildActionMigrator.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildActionMigrator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2004-2010, Sun Microsystems, Inc., Serban Iordache
+ * Copyright (c) 2018 IKEDA Yasuyuki
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,61 +24,38 @@
 package org.jvnet.hudson.plugins.groovypostbuild;
 
 import com.jenkinsci.plugins.badge.action.BadgeAction;
-import hudson.model.BuildBadgeAction;
 
 /**
- * Left for backward binary compatibilities.
+ * Converts GroovyPostbuildAction to {@link BadgeAction}
  *
- * This doesn't provide any actual features.
- *
- * @deprecated use {@link BadgeAction} instead.
  */
-@Deprecated
-public class GroovyPostbuildAction implements BuildBadgeAction {
-    private GroovyPostbuildAction() {}
+/*package*/ class GroovyPostbuildActionMigrator {
+    private transient String iconPath;
+    private transient String text;
+    private transient String color;
+    private transient String background;
+    private transient String border;
+    private transient String borderColor;
+    private transient String link;
 
-    /* Action methods */
-    public String getUrlName() {
-        return "";
-    }
+    protected BadgeAction readResolve() {
+        String style = "";
+        if (border != null) {
+            style += "border: " + border + " solid " + (borderColor != null ? borderColor : "") + ";";
+        }
+        if (background != null) {
+            style += "background: " + background + ";";
+        }
+        if (color != null) {
+            if (color.startsWith("jenkins-!-color")) {
+                style += "color: var(--" + color.replaceFirst("jenkins-!-color-", "") + ");";
+            } else if (color.startsWith("jenkins-!-")) {
+                style += "color: var(--" + color.replaceFirst("jenkins-!-", "") + ");";
+            } else {
+                style += "color: " + color + ";";
+            }
+        }
 
-    public String getDisplayName() {
-        return "";
-    }
-
-    public String getIconFileName() {
-        return null;
-    }
-
-    public boolean isTextOnly() {
-        return false;
-    }
-
-    public String getIconPath() {
-        return null;
-    }
-
-    public String getText() {
-        return "";
-    }
-
-    public String getColor() {
-        return "#000000";
-    }
-
-    public String getBackground() {
-        return "#FFFF00";
-    }
-
-    public String getBorder() {
-        return "1px";
-    }
-
-    public String getBorderColor() {
-        return "#C0C000";
-    }
-
-    public String getLink() {
-        return null;
+        return new BadgeAction(null, iconPath, text, null, style, link, null);
     }
 }

--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildDescriptor.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildDescriptor.java
@@ -23,7 +23,6 @@
  */
 package org.jvnet.hudson.plugins.groovypostbuild;
 
-import com.jenkinsci.plugins.badge.action.BadgeAction;
 import hudson.Extension;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
@@ -86,9 +85,9 @@ public class GroovyPostbuildDescriptor extends BuildStepDescriptor<Publisher> {
 
     @Initializer(before = InitMilestone.PLUGINS_STARTED)
     public static void addAliases() {
-        // migration from groovy-postbuild 2.3.1- to badge-plugin
+        // migration from groovy-postbuild 2.3.1 to badge-plugin
         Run.XSTREAM2.addCompatibilityAlias(
-                "org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildAction", BadgeAction.class);
+                "org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildAction", GroovyPostbuildActionMigrator.class);
         Run.XSTREAM2.addCompatibilityAlias(
                 "org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildSummaryAction",
                 GroovyPostbuildSummaryActionMigrator.class);

--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
@@ -184,7 +184,13 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
         @Whitelisted
         public void addInfoBadge(String text) {
             build.addAction(new BadgeAction(
-                    null, Ionicons.getIconClassName("information-circle"), text, null, "color: var(--blue)", null, null));
+                    null,
+                    Ionicons.getIconClassName("information-circle"),
+                    text,
+                    null,
+                    "color: var(--blue)",
+                    null,
+                    null));
         }
 
         @Whitelisted
@@ -196,7 +202,13 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
         @Whitelisted
         public void addErrorBadge(String text) {
             build.addAction(new BadgeAction(
-                    null, Ionicons.getIconClassName("remove-circle"), text, null, "color: var(--error-color)", null, null));
+                    null,
+                    Ionicons.getIconClassName("remove-circle"),
+                    text,
+                    null,
+                    "color: var(--error-color)",
+                    null,
+                    null));
         }
 
         @Whitelisted

--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
@@ -147,7 +147,7 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
 
         @Whitelisted
         public void addShortText(String text) {
-            build.addAction(new BadgeAction(null, null, text, null, null, null));
+            build.addAction(new BadgeAction(null, null, text, null, null, null, null));
         }
 
         @Whitelisted
@@ -168,40 +168,40 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
                 }
             }
 
-            build.addAction(new BadgeAction(null, null, text, null, style, null));
+            build.addAction(new BadgeAction(null, null, text, null, style, null, null));
         }
 
         @Whitelisted
         public void addBadge(String icon, String text) {
-            build.addAction(new BadgeAction(null, icon, text, null, null, null));
+            build.addAction(new BadgeAction(null, icon, text, null, null, null, null));
         }
 
         @Whitelisted
         public void addBadge(String icon, String text, String link) {
-            build.addAction(new BadgeAction(null, icon, text, null, null, link));
+            build.addAction(new BadgeAction(null, icon, text, null, null, link, null));
         }
 
         @Whitelisted
         public void addInfoBadge(String text) {
             build.addAction(new BadgeAction(
-                    null, Ionicons.getIconClassName("information-circle"), text, null, "color: var(--blue)", null));
+                    null, Ionicons.getIconClassName("information-circle"), text, null, "color: var(--blue)", null, null));
         }
 
         @Whitelisted
         public void addWarningBadge(String text) {
             build.addAction(new BadgeAction(
-                    null, Ionicons.getIconClassName("warning"), text, null, "color: var(--warning-color)", null));
+                    null, Ionicons.getIconClassName("warning"), text, null, "color: var(--warning-color)", null, null));
         }
 
         @Whitelisted
         public void addErrorBadge(String text) {
             build.addAction(new BadgeAction(
-                    null, Ionicons.getIconClassName("remove-circle"), text, null, "color: var(--error-color)", null));
+                    null, Ionicons.getIconClassName("remove-circle"), text, null, "color: var(--error-color)", null, null));
         }
 
         @Whitelisted
         public void addHtmlBadge(String html) {
-            build.addAction(new BadgeAction(null, null, html, null, null, null));
+            build.addAction(new BadgeAction(null, null, html, null, null, null, null));
         }
 
         @Whitelisted
@@ -230,7 +230,7 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
         }
 
         public BadgeSummaryAction createSummary(String icon) {
-            BadgeSummaryAction action = new BadgeSummaryAction(null, icon, null, null, null, null);
+            BadgeSummaryAction action = new BadgeSummaryAction(null, icon, null, null, null, null, null);
             build.addAction(action);
             return action;
         }

--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildSummaryActionMigrator.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildSummaryActionMigrator.java
@@ -37,6 +37,6 @@ import com.jenkinsci.plugins.badge.action.BadgeSummaryAction;
 
     protected BadgeSummaryAction readResolve() {
         return new BadgeSummaryAction(
-                null, iconPath, textBuilder != null ? textBuilder.toString() : null, null, null, null);
+                null, iconPath, textBuilder != null ? textBuilder.toString() : null, null, null, null, null);
     }
 }

--- a/src/test/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorderTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorderTest.java
@@ -52,7 +52,6 @@ import org.hamcrest.Matchers;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.FailureBuilder;
 import org.jvnet.hudson.test.Issue;
@@ -185,7 +184,7 @@ class GroovyPostbuildRecorderTest {
      * @throws Exception
      */
     @Test
-    void testBehaviorNotAffectWithUnstableBuildSuceedingScript() throws Exception {
+    void testBehaviorNotAffectWithUnstableBuildSucceedingScript() throws Exception {
         List<Integer> behaviors = Arrays.asList(0, 1, 2);
         for (int behavior : behaviors) {
             FreeStyleProject p = j.createFreeStyleProject();
@@ -213,7 +212,7 @@ class GroovyPostbuildRecorderTest {
      * @throws Exception
      */
     @Test
-    void testBehaviorNotAffectWithFailingBuildSuceedingScript() throws Exception {
+    void testBehaviorNotAffectWithFailingBuildSucceedingScript() throws Exception {
         List<Integer> behaviors = Arrays.asList(0, 1, 2);
         for (int behavior : behaviors) {
             FreeStyleProject p = j.createFreeStyleProject();
@@ -666,7 +665,6 @@ class GroovyPostbuildRecorderTest {
         assertEquals(List.of("test2"), Lists.transform(b.getActions(BadgeAction.class), AbstractBadgeAction::getText));
     }
 
-    @Disabled("badges plugin 3.x breaks compatibility for this use case, use Pipeline instead of freestyle")
     @Test
     void testRemoveSummary() throws Exception {
         j.jenkins.setMarkupFormatter(RawHtmlMarkupFormatter.INSTANCE);
@@ -678,8 +676,8 @@ class GroovyPostbuildRecorderTest {
         p.getPublishersList()
                 .add(new GroovyPostbuildRecorder(
                         new SecureGroovyScript("""
-                                manager.createSummary('attribute.png').appendText('Test1', false, false, false, 'Black');
-                                manager.createSummary('attribute.png').appendText('Test2', false, false, false, 'Black');
+                                manager.createSummary('attribute.png').setText('Test1');
+                                manager.createSummary('attribute.png').setText('Test2');
                                 manager.removeSummary(0);
                                 """, true, Collections.emptyList()),
                         2, // behavior
@@ -700,7 +698,7 @@ class GroovyPostbuildRecorderTest {
         p.getPublishersList()
                 .add(new GroovyPostbuildRecorder(
                         new SecureGroovyScript("""
-                                manager.createSummary('attribute.png').appendText('Test1', false, false, false, 'Black');
+                                manager.createSummary('attribute.png').setText('Test1');
                                 manager.removeSummaries();
                                 """, true, Collections.emptyList()),
                         2, // behavior

--- a/src/test/resources/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorderTest/testBadgeMigration/jobs/groovy-postbuild-2.3.1/config.xml
+++ b/src/test/resources/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorderTest/testBadgeMigration/jobs/groovy-postbuild-2.3.1/config.xml
@@ -16,7 +16,7 @@
     <org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder plugin="groovy-postbuild@2.4-SNAPSHOT">
       <script plugin="script-security@1.15">
         <script>manager.addBadge(&apos;success.gif&apos;, &apos;shortText&apos;, &apos;https://jenkins.io/&apos;);
-manager.createSummary(&apos;info.gif&apos;).appendText(&apos;&lt;b&gt;summaryText&lt;/b&gt;&apos;, false);</script>
+manager.createSummary(&apos;info.gif&apos;).setText(&apos;&lt;b&gt;summaryText&lt;/b&gt;&apos;);</script>
         <sandbox>true</sandbox>
       </script>
       <behavior>0</behavior>


### PR DESCRIPTION
Follow-up for #190, fixing compatibility with badge-plugin 3.x (see https://github.com/jenkinsci/badge-plugin/pull/304)

* Replace deprecated methods with non-deprecated ones
* Add migrator for badges
* Use the latest bom containing the latest badge plugin 3.x

### Testing done

Fixed failing tests, `mvn clean verify` works fine.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
