### PR TITLE
GroovyPostbuildRecorder.java: add a way to removeBadgesOnly()

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,17 @@ You can always use *approved methods*, but you can use *non-approved methods* on
 -   `addWarningBadge(text)` - puts a badge with ![](docs/images/warning.gif) warning icon and the given text.
 -   `addErrorBadge(text)` - puts a badge with ![](docs/images/error.gif) error icon and the given text.
 -   `addHtmlBadge(html)` - puts a badge with html source. Unsafe html codes will be removed.
--   `removeBadges()` - removes all badges from the current build. It is often used with `setBuildNumber`.
--   `removeBadge(index)` - removes the badge with the given index. It is often used with `setBuildNumber`.
+-   `removeBadges()` - removes all badges *and summaries* from the current build. Badges and summaries
+    are both represented as subclasses of the same base action class, and this method removes any action
+    of that base class, so it is not limited to badges despite its name. It is often used with `setBuildNumber`.
+    If you only want to remove badges and leave summaries alone, use `removeBadgesOnly()` instead.
+-   `removeBadge(index)` - removes the badge-or-summary with the given index, for the same reason described
+    for `removeBadges()`. It is often used with `setBuildNumber`. If you only want to remove a badge, use
+    `removeBadgeOnly(index)` instead.
+-   `removeBadgesOnly()` - removes only the badges from the current build, leaving any summaries untouched.
+-   `removeBadgeOnly(index)` - removes only the badge with the given index, leaving any summaries untouched.
+    Note that this index is into the badge-only list, so index 0 here is not necessarily the same action as
+    index 0 for `removeBadge(index)` when the build also has summaries.
 -   `addBadge(icon, text)` - puts a badge with the given icon and text.
     Provides the following icons:
 

--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
@@ -210,6 +210,27 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
             return (r != null) ? r.toString() : null;
         }
 
+        /** WARNING: This method removes actually {@link AbstractBadgeAction} objects
+         *  from the {@link #build}, which include both actual {@link BadgeAction badges}
+         *  seen in the build list column, and the {@link BadgeSummaryAction summaries}
+         *  seen on the build page.<br/>
+         *
+         *  It is a historic misnomer, so you may want actually the variants constrained
+         *  to those Action types, e.g. {@link #removeBadgesOnly()}
+         *  or {@link #removeSummaries()}.
+         *
+         *  Removal in this context means that the {@link Action} would no longer be
+         *  linked to the specified build. An object in the pipeline (if someone gets
+         *  the reference, e.g. via new Badge Plugin API) may still exist until it is
+         *  no longer used and gets garbage-collected. Maybe someone can re-add such
+         *  an Action object to same or different build before it evaporates, though.<br/>
+         *
+         *  @see #removeBadge(int)
+         *  @see #removeBadgesOnly()
+         *  @see #removeBadgeOnly(int)
+         *  @see #removeSummaries()
+         *  @see #removeSummary(int)
+         */
         @Whitelisted
         public void removeBadges() {
             List<AbstractBadgeAction> badgeActions = build.getActions(AbstractBadgeAction.class);
@@ -218,6 +239,17 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
             }
         }
 
+        /** WARNING: This method removes actually {@link AbstractBadgeAction} objects
+         *  from the {@link #build}, which include both actual {@link BadgeAction badges}
+         *  seen in the build list column, and the {@link BadgeSummaryAction summaries}
+         *  seen on the build page. For more details, see {@link #removeBadges()}.<br/>
+         *
+         *  @see #removeBadges()
+         *  @see #removeBadgesOnly()
+         *  @see #removeBadgeOnly(int)
+         *  @see #removeSummaries()
+         *  @see #removeSummary(int)
+         */
         @Whitelisted
         public void removeBadge(int index) {
             List<AbstractBadgeAction> badgeActions = build.getActions(AbstractBadgeAction.class);
@@ -229,12 +261,55 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
             }
         }
 
+        /** For details, see {@link #removeBadges()}.<br/>
+         *
+         *  @see #removeBadges()
+         *  @see #removeBadge(int)
+         *  @see #removeBadgeOnly(int)
+         *  @see #removeSummaries()
+         *  @see #removeSummary(int)
+         */
+        @Whitelisted
+        public void removeBadgesOnly() {
+            List<BadgeAction> badgeActions = build.getActions(BadgeAction.class);
+            for (BadgeAction a : badgeActions) {
+                build.removeAction(a);
+            }
+        }
+
+        /** For details, see {@link #removeBadges()}.<br/>
+         *
+         *  @see #removeBadges()
+         *  @see #removeBadge(int)
+         *  @see #removeBadgesOnly()
+         *  @see #removeSummaries()
+         *  @see #removeSummary(int)
+         */
+        @Whitelisted
+        public void removeBadgeOnly(int index) {
+            List<BadgeAction> badgeActions = build.getActions(BadgeAction.class);
+            if (index < 0 || index >= badgeActions.size()) {
+                listener.error("Invalid badge index: " + index + ". Allowed values: 0 .. " + (badgeActions.size() - 1));
+            } else {
+                BadgeAction action = badgeActions.get(index);
+                build.removeAction(action);
+            }
+        }
+
         public BadgeSummaryAction createSummary(String icon) {
             BadgeSummaryAction action = new BadgeSummaryAction(null, icon, null, null, null, null);
             build.addAction(action);
             return action;
         }
 
+        /** For details, see {@link #removeBadges()}.<br/>
+         *
+         *  @see #removeBadges()
+         *  @see #removeBadge(int)
+         *  @see #removeBadgesOnly()
+         *  @see #removeBadgeOnly(int)
+         *  @see #removeSummary(int)
+         */
         public void removeSummaries() {
             List<BadgeSummaryAction> summaryActions = build.getActions(BadgeSummaryAction.class);
             for (BadgeSummaryAction a : summaryActions) {
@@ -242,6 +317,14 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
             }
         }
 
+        /** For details, see {@link #removeBadges()}.<br/>
+         *
+         *  @see #removeBadges()
+         *  @see #removeBadge(int)
+         *  @see #removeBadgesOnly()
+         *  @see #removeBadgeOnly(int)
+         *  @see #removeSummaries()
+         */
         public void removeSummary(int index) {
             List<BadgeSummaryAction> summaryActions = build.getActions(BadgeSummaryAction.class);
             if (index < 0 || index >= summaryActions.size()) {

--- a/src/test/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorderTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorderTest.java
@@ -667,6 +667,62 @@ class GroovyPostbuildRecorderTest {
         assertEquals(List.of("test2"), Lists.transform(b.getActions(BadgeAction.class), AbstractBadgeAction::getText));
     }
 
+    @Test
+    void testRemoveBadgesOnlyLeavesSummaries() throws Exception {
+        // removeBadgesOnly() is constrained to BadgeAction and must not touch BadgeSummaryAction
+        String template = "method org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder$BadgeManager %s";
+        ScriptApproval.get().approveSignature(template.formatted("createSummary java.lang.String"));
+        FreeStyleProject p = j.createFreeStyleProject();
+
+        p.getPublishersList()
+                .add(new GroovyPostbuildRecorder(
+                        new SecureGroovyScript(
+                                """
+                                manager.addShortText('test1');
+                                manager.addShortText('test2');
+                                manager.createSummary('attribute.png');
+                                manager.removeBadgesOnly();
+                                """,
+                                true, // sandbox
+                                Collections.emptyList()),
+                        2, // behavior
+                        false // runForMatrixParent
+                        ));
+
+        FreeStyleBuild b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        assertEquals(Collections.emptyList(), b.getActions(BadgeAction.class));
+        assertEquals(1, b.getActions(BadgeSummaryAction.class).size());
+    }
+
+    @Test
+    void testRemoveBadgesAlsoRemovesSummaries() throws Exception {
+        // Pins today's (surprising) behavior: removeBadges() filters on the shared
+        // AbstractBadgeAction superclass, so it removes summaries too, not just badges.
+        // If this is ever fixed to match its name, this test must be updated deliberately.
+        String template = "method org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder$BadgeManager %s";
+        ScriptApproval.get().approveSignature(template.formatted("createSummary java.lang.String"));
+        FreeStyleProject p = j.createFreeStyleProject();
+
+        p.getPublishersList()
+                .add(new GroovyPostbuildRecorder(
+                        new SecureGroovyScript(
+                                """
+                                manager.addShortText('test1');
+                                manager.addShortText('test2');
+                                manager.createSummary('attribute.png');
+                                manager.removeBadges();
+                                """,
+                                true, // sandbox
+                                Collections.emptyList()),
+                        2, // behavior
+                        false // runForMatrixParent
+                        ));
+
+        FreeStyleBuild b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        assertEquals(Collections.emptyList(), b.getActions(BadgeAction.class));
+        assertEquals(Collections.emptyList(), b.getActions(BadgeSummaryAction.class));
+    }
+
     @Disabled("badges plugin 3.x breaks compatibility for this use case, use Pipeline instead of freestyle")
     @Test
     void testRemoveSummary() throws Exception {


### PR DESCRIPTION
As discovered during investigation that led to https://github.com/jenkinsci/badge-plugin/pull/362 this plugin's `removeBadges()` action actually removes both badges and summaries (is not limited to specifically `BadgeAction`).

There are a couple of ways out of this:
* Define a new method name for the new activity = least surprise for existing consumers that might rely on this (mis-)behavior.
* Accept that this was a bug and redefine `removeBadges()`  to remove only badges = least surprise for consumers of the current Badge API plugin, and more intuitively matching the name.
  * If anyone wanted a way to remove any derivative of `AbstractBadgeAction` in one go, a separate method specifically for that can be used, again more intuitively fitting; maybe add a namesake to Badge plugin too for easiest co-existence. This would be effectively about swapping the names and updating javadocs of methods impacted by this PR's initial commit.
  * The Badge plugin currently does remove only badges and only summaries in respective methods, so going with this option is arguably least-surprise as well (ecosystem wide coherence as well as intuitively matching the name to activity).

For now, I went with the first option, but consider the second one superior (albeit a slightly breaking change, potentially). Up to maintainers :)

### Testing done

None yet, a theoretical fix.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
  * Subject to maybe going with the second option described above and using different names in the end
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
