### PR TITLE
Fix malformed CSS custom property and border declaration in badge styles

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
+++ b/src/main/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorder.java
@@ -153,14 +153,14 @@ public class GroovyPostbuildRecorder extends Recorder implements MatrixAggregata
         @Whitelisted
         public void addShortText(String text, String color, String background, String border, String borderColor) {
             // translate old styling to new field
-            String style = "border: " + (border != null ? border : "") + " solid "
-                    + (borderColor != null ? borderColor : "") + ";";
+            String style = "border: " + (border != null ? border : "") + " solid"
+                    + (borderColor != null ? " " + borderColor : "") + ";";
             if (background != null) {
                 style += "background: " + background + ";";
             }
             if (color != null) {
-                if (color.startsWith("jenkins-!-color")) {
-                    style += "color: var(--" + color.replaceFirst("jenkins-!-color", "") + ");";
+                if (color.startsWith("jenkins-!-color-")) {
+                    style += "color: var(--" + color.replaceFirst("jenkins-!-color-", "") + ");";
                 } else if (color.startsWith("jenkins-!-")) {
                     style += "color: var(--" + color.replaceFirst("jenkins-!-", "") + ");";
                 } else {

--- a/src/test/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorderTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/groovypostbuild/GroovyPostbuildRecorderTest.java
@@ -559,6 +559,53 @@ class GroovyPostbuildRecorderTest {
     }
 
     @Test
+    void testAddShortTextWithColorVariablePrefixTranslatesToCssCustomProperty() throws Exception {
+        // 'jenkins-!-color-<name>' must translate to the CSS custom property
+        // var(--<name>), not var(---<name>) with a stray extra hyphen.
+        FreeStyleProject p = j.createFreeStyleProject();
+
+        p.getPublishersList()
+                .add(new GroovyPostbuildRecorder(
+                        new SecureGroovyScript(
+                                "manager.addShortText('testing', 'jenkins-!-color-dark-indigo', null, null, null);",
+                                true, // sandbox
+                                Collections.emptyList()),
+                        2, // behavior
+                        false // runForMatrixParent
+                        ));
+
+        FreeStyleBuild b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+
+        String style = b.getAction(BadgeAction.class).getStyle();
+        assertThat(style, Matchers.containsString("var(--dark-indigo)"));
+        assertThat(style, Matchers.not(Matchers.containsString("var(---dark-indigo)")));
+    }
+
+    @Test
+    void testAddShortTextWithNullBorderColorEmitsWellFormedBorder() throws Exception {
+        // A null border colour must not leave a stray space before the
+        // semicolon (e.g. "border: 1px solid ;"), which browsers drop as
+        // malformed and which causes the border to disappear entirely.
+        FreeStyleProject p = j.createFreeStyleProject();
+
+        p.getPublishersList()
+                .add(new GroovyPostbuildRecorder(
+                        new SecureGroovyScript(
+                                "manager.addShortText('testing', null, null, '1px', null);",
+                                true, // sandbox
+                                Collections.emptyList()),
+                        2, // behavior
+                        false // runForMatrixParent
+                        ));
+
+        FreeStyleBuild b = j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+
+        String style = b.getAction(BadgeAction.class).getStyle();
+        assertThat(style, Matchers.containsString("border: 1px solid;"));
+        assertThat(style, Matchers.not(Matchers.containsString("solid ;")));
+    }
+
+    @Test
     void testAddHtmlBadge() throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
 


### PR DESCRIPTION
Two defects in the style `addShortText` generates. Both are silent: the browser drops the malformed declaration and the badge simply renders wrong.

**Colour.** `jenkins-!-color-dark-indigo` produced `color: var(---dark-indigo)` — three hyphens, so the custom-property name is invalid and the badge falls back to the default colour. The prefix being stripped was `jenkins-!-color` without the trailing hyphen. `SCRIPT_FOR_MATRIX` in the test class uses exactly this value, so it is a live path.

**Border.** A null border colour produced `border: 1px solid ;`, which is malformed, so the border disappears entirely.

Two tests added. Both fail on master:

```
Expected: a string containing "var(--dark-indigo)" but: was "border:  solid ;color: var(---dark-indigo);"
Expected: a string containing "border: 1px solid;" but: was "border: 1px solid ;"
```

Nothing asserted on `getStyle()` before, which is how both survived.
